### PR TITLE
Support handling very high limits/0 as ttl

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gcra (1.0.1)
+    gcra (1.0.2)
 
 GEM
   remote: https://rubygems.org/
@@ -29,6 +29,3 @@ DEPENDENCIES
   gcra!
   redis (~> 3.3)
   rspec (~> 3.5)
-
-BUNDLED WITH
-   1.13.6

--- a/lib/gcra/version.rb
+++ b/lib/gcra/version.rb
@@ -1,3 +1,3 @@
 module GCRA
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.0.2'.freeze
 end


### PR DESCRIPTION
With very high limits the calculated TTL may be set to 0. Redis does not support 0 as expiration time for its keys.
Therefore to properly remove those keys from redis again, this sets the value to 1 (in milliseconds) if the given ttl_nano is less than 1 millisecond.