### PR TITLE
Ensure the key argument is a String

### DIFF
--- a/lib/gcra/rate_limiter.rb
+++ b/lib/gcra/rate_limiter.rb
@@ -23,6 +23,7 @@ module GCRA
     end
 
     def limit(key, quantity)
+      key = key.to_s unless key.is_a?(String)
       i = 0
 
       while i < MAX_ATTEMPTS


### PR DESCRIPTION
Small change that ensures the key argument is a String. Otherwise we get a "no implicit conversion of Integer into String" error when passing Integers, for example user.id