### PR TITLE
Redis performance

### DIFF
--- a/lib/gcra/redis_store.rb
+++ b/lib/gcra/redis_store.rb
@@ -37,17 +37,11 @@ module GCRA
     end
 
     # Set the value of key only if it is not already set. Return whether the value was set.
-    # Also set the key's expiration (ttl, in seconds). The operations are not performed atomically.
+    # Also set the key's expiration (ttl, in seconds).
     def set_if_not_exists_with_ttl(key, value, ttl_nano)
       full_key = @key_prefix + key
-      did_set = @redis.setnx(full_key, value)
-
-      if did_set
-        ttl_milli = calculate_ttl_milli(ttl_nano)
-        @redis.pexpire(full_key, ttl_milli)
-      end
-
-      return did_set
+      ttl_milli = calculate_ttl_milli(ttl_nano)
+      @redis.set(full_key, value, nx: true, px: ttl_milli)
     end
 
     # Atomically compare the value at key to the old value. If it matches, set it to the new value

--- a/lib/gcra/redis_store.rb
+++ b/lib/gcra/redis_store.rb
@@ -23,10 +23,12 @@ module GCRA
     # Returns the value of the key or nil, if it isn't in the store.
     # Also returns the time from the Redis server, with microsecond precision.
     def get_with_time(key)
-      time_response = @redis.time # returns tuple (seconds since epoch, microseconds)
+      time_response, value = @redis.pipelined do
+        @redis.time # returns tuple (seconds since epoch, microseconds)
+        @redis.get(@key_prefix + key)
+      end
       # Convert tuple to nanoseconds
       time = (time_response[0] * 1_000_000 + time_response[1]) * 1_000
-      value = @redis.get(@key_prefix + key)
       if value != nil
         value = value.to_i
       end

--- a/lib/gcra/redis_store.rb
+++ b/lib/gcra/redis_store.rb
@@ -15,7 +15,7 @@ module GCRA
   return 1
   EOF
     CAS_SCRIPT_MISSING_KEY_RESPONSE = 'key does not exist'.freeze
-    SCRIPT_NOT_IN_CACHE_RESPOSNE = 'NOSCRIPT No matching script. Please use EVAL.'
+    SCRIPT_NOT_IN_CACHE_RESPONSE = 'NOSCRIPT No matching script. Please use EVAL.'
 
     def initialize(redis, key_prefix)
       @redis = redis
@@ -59,7 +59,7 @@ module GCRA
       rescue Redis::CommandError => e
         if e.message == CAS_SCRIPT_MISSING_KEY_RESPONSE
           return false
-        elsif e.message == SCRIPT_NOT_IN_CACHE_RESPOSNE && !retried
+        elsif e.message == SCRIPT_NOT_IN_CACHE_RESPONSE && !retried
           @redis.script('load', CAS_SCRIPT)
           retried = true
           retry

--- a/spec/lib/gcra/redis_store_spec.rb
+++ b/spec/lib/gcra/redis_store_spec.rb
@@ -123,6 +123,31 @@ RSpec.describe GCRA::RedisStore do
       expect(swapped).to eq(true)
       expect(redis.ttl('gcra-ruby-specs:foo')).to be <= 1
     end
+
+    it 'handles the script cache being purged (gracefully reloads script)' do
+      redis.set('gcra-ruby-specs:foo', 2_000_000_000_000_000_000)
+
+      swapped = store.compare_and_set_with_ttl(
+        'foo', 2_000_000_000_000_000_000, 3_000_000_000_000_000_000, 10 * 1_000_000_000
+      )
+
+      expect(swapped).to eq(true)
+      expect(redis.get('gcra-ruby-specs:foo')).to eq('3000000000000000000')
+      expect(redis.ttl('gcra-ruby-specs:foo')).to be > 8
+      expect(redis.ttl('gcra-ruby-specs:foo')).to be <= 10
+
+      # purge the script cache, this will trigger an exception branch that reloads the script
+      redis.script('flush')
+
+      swapped = store.compare_and_set_with_ttl(
+        'foo', 3_000_000_000_000_000_000, 4_000_000_000_000_000_000, 10 * 1_000_000_000
+      )
+
+      expect(swapped).to eq(true)
+      expect(redis.get('gcra-ruby-specs:foo')).to eq('4000000000000000000')
+      expect(redis.ttl('gcra-ruby-specs:foo')).to be > 8
+      expect(redis.ttl('gcra-ruby-specs:foo')).to be <= 10
+    end
   end
 
   context 'functional test with RateLimiter' do

--- a/spec/lib/gcra/redis_store_spec.rb
+++ b/spec/lib/gcra/redis_store_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'redis'
+require 'digest/sha1'
 require_relative '../../../lib/gcra/rate_limiter'
 require_relative '../../../lib/gcra/redis_store'
 
@@ -28,6 +29,13 @@ RSpec.describe GCRA::RedisStore do
 
   after do
     cleanup_redis
+  end
+
+  specify "canary: CAS_SHA is up to date" do
+    actual_sha = Digest::SHA1.hexdigest(GCRA::RedisStore::CAS_SCRIPT)
+    stored_sha = GCRA::RedisStore::CAS_SHA
+    expect(actual_sha).to eq(stored_sha),
+      "CAS_SCRIPT was updated without adjusting CAS_SHA! Please change CAS_SHA to '#{stored_sha}'"
   end
 
   describe '#get_with_time' do


### PR DESCRIPTION
We are using this gem at ShippingEasy to manage rate limiting API endpoints.  It works great, but while reviewing the source I found a few areas where its performance could be improved:

* `evalsha` should be preferred to `eval`, since it reduces script compilation and network overhead (490b7be28138cbf207828b324646648263e68601 and 6474c7aace4a411f7e5159a1a3e490fbb4b1feb9)
* independent adjacent calls to redis should be [pipelined](https://redis.io/topics/pipelining) to avoid multiple round trips (035d6ed40a52a38aa74bb18c011ee85012ee4a2b)
* A combination of `SETNX` and `PEXPIRE` is equivalent to and can be replaced with a single `SET` call with `NX` and `PX` options (722c516cdc01b067a3ba4083be0e1207fbb0587f).  As a beneficial side effect, not only does this perform better but it turns `set_if_not_exists_with_ttl` into an atomic operation.