### PR TITLE
fix race condition for "compare and set"

### DIFF
--- a/spec/lib/gcra/redis_store_spec.rb
+++ b/spec/lib/gcra/redis_store_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe GCRA::RedisStore do
     actual_sha = Digest::SHA1.hexdigest(GCRA::RedisStore::CAS_SCRIPT)
     stored_sha = GCRA::RedisStore::CAS_SHA
     expect(actual_sha).to eq(stored_sha),
-      "CAS_SCRIPT was updated without adjusting CAS_SHA! Please change CAS_SHA to '#{stored_sha}'"
+      "CAS_SCRIPT was updated without adjusting CAS_SHA! Please change CAS_SHA to '#{actual_sha}'"
   end
 
   describe '#get_with_time' do
@@ -88,13 +88,14 @@ RSpec.describe GCRA::RedisStore do
   end
 
   describe '#compare_and_set_with_ttl' do
-    it 'with no existing key, returns false' do
+    it 'with no existing key, returns true' do
       swapped = store.compare_and_set_with_ttl(
         'foo', 2_000_000_000_000_000_000, 3_000_000_000_000_000_000, 1 * 1_000_000_000
       )
 
-      expect(swapped).to eq(false)
-      expect(redis.get('gcra-ruby-specs:foo')).to be_nil
+      expect(swapped).to eq(true)
+      expect(redis.get('gcra-ruby-specs:foo')).to eq('3000000000000000000')
+      expect(redis.ttl('gcra-ruby-specs:foo')).to eq(1)
     end
 
     it 'with an existing key and not matching old value, returns false' do


### PR DESCRIPTION
I ran into an issue which caused the Lua script to return an error if the key does not exist. This issue arises in a system with a high volume of concurrent traffic for the same key, and a low TTL value.

The `tat_from_store` value is set [at the top](https://github.com/Barzahlen/gcra-ruby/blob/2c6e5d2004812a4ce5536d8ad107ae94cb560176/lib/gcra/rate_limiter.rb#L32) of the loop, which is then used [at the bottom](https://github.com/Barzahlen/gcra-ruby/blob/2c6e5d2004812a4ce5536d8ad107ae94cb560176/lib/gcra/rate_limiter.rb#L77) to determine if the key should be _set_, or _updated_.

If the key exists at the top, but then expires before the script reaches the bottom, the wrong path is taken.

Usually, this isn't an issue, since the script retries 10 times before giving up. However, with a high enough concurrent throughput for the same key (which is a likely scenario, given the exact purpose of this library), this situation can repeat itself 10 times, resulting in the script failing.

From what I understand, there's no reason why the Lua script can't set the value itself and behave similar to `set_if_not_exists_with_ttl`, if it determines the key does not exist.

An alternative approach would be to _always_ run the Lua script, as it now does what `set_if_not_exists_with_ttl` does, and more, but I'm guessing (without having benchmarked it) that we still want the regular `set` call to stay in place, as it'll run faster than the Lua script.