### PR TITLE
Add support for automatically reconnecting if a readonly host was detected

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gcra (1.1.0)
+    gcra (1.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ require 'gcra/redis_store'
 
 redis = Redis.new(host: 'localhost', port: 6379, timeout: 0.1)
 key_prefix = 'rate-limit-app1:'
-store = GCRA::RedisStore.new(redis, key_prefix)
+store = GCRA::RedisStore.new(
+          redis,
+          key_prefix,
+          { reconnect_on_readonly: false },
+        )
 
 rate_period = 0.5  # Two requests per second
 max_burst = 10     # Allow 10 additional requests as a burst

--- a/lib/gcra/version.rb
+++ b/lib/gcra/version.rb
@@ -1,3 +1,3 @@
 module GCRA
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.2.0'.freeze
 end


### PR DESCRIPTION
When the primary of a cluster fails over to a secondary the connection remains open to the primary.
Trying to write against the new secondary will not work, as it is in readonly mode.
In order to better handle this, this allows configuring GCRA to trigger an automatic reconnect.
That behaviour is optional though and requires explicit opt-in